### PR TITLE
Updated to .NET 4.7.2

### DIFF
--- a/TheLeftExit/BaggNough/App.config
+++ b/TheLeftExit/BaggNough/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
 </configuration>

--- a/TheLeftExit/BaggNough/BaggNough.csproj
+++ b/TheLeftExit/BaggNough/BaggNough.csproj
@@ -8,7 +8,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>BaggNough</RootNamespace>
     <AssemblyName>BaggNough</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>


### PR DESCRIPTION
Кортежи типа (int,int) не поддерживаются нативно в версиях .NET ранее 4.7. В .NET 4.6.1 мой проект не собирается.
Также предлагаю обновить до последней версии весь репозиторий.